### PR TITLE
Update to Scenic v0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ you. This is the easiest way to set up a new Scenic project.
 
 ## Erlang/Elixir versions
 
-Please note, it currently needs OTP 21 and Elixir 1.7. If you have trouble
-compiling, please check that you are running those versions first.
+Please note, it currently needs at least OTP 21 and Elixir 1.7. If you have
+trouble compiling, please check that you are running those versions first.
 
 ## Install Prerequisites
 
@@ -14,7 +14,7 @@ The design of Scenic goes to great lengths to minimize its dependencies to just
 the minimum. Namely, it needs Erlang/Elixir and OpenGL.
 
 Rendering your application into a window on your local computer (MacOS, Ubuntu
-and others) is done by the `scenic_driver_glfw` driver. It uses the GLFW and
+and others) is done by the `scenic_driver_local` driver. It uses the GLFW and
 GLEW libraries to connect to OpenGL.
 
 The instructions below assume you have already installed Elixir/Erlang. If you
@@ -32,7 +32,7 @@ brew install glfw3 glew pkg-config
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ### Installing on Ubuntu 16
 
@@ -44,7 +44,7 @@ sudo apt-get install pkgconf libglfw3 libglfw3-dev libglew1.13 libglew-dev
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ### Installing on Ubuntu 18
 
@@ -56,7 +56,7 @@ sudo apt-get install pkgconf libglfw3 libglfw3-dev libglew2.0 libglew-dev
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ### Installing on Arch Linux
 
@@ -67,7 +67,7 @@ sudo pacman -S pkgconf glew glfw-x11
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ### Installing on Fedora
 
@@ -79,7 +79,7 @@ sudo dnf install pkgconf glew-devel glfw-devel
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ### Installing on FreeBSD
 
@@ -92,7 +92,7 @@ sudo pkg install devel/gmake devel/pkgconf devel/elixir-hex devel/rebar3 \
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ### Installing on NixOS 18.09
 

--- a/lib/mix/tasks/new.ex
+++ b/lib/mix/tasks/new.ex
@@ -140,6 +140,7 @@ defmodule Mix.Tasks.Scenic.New do
     create_directory("lib")
     create_directory("lib/components")
     create_file("lib/#{app}.ex", app_template(assigns))
+    create_file("lib/assets.ex", assets_template(assigns))
 
     create_directory("lib/scenes")
     create_file("lib/scenes/home.ex", scene_home_template(assigns))
@@ -187,6 +188,7 @@ defmodule Mix.Tasks.Scenic.New do
     mix_exs: "templates/new/mix.exs.eex",
     config: "templates/new/config/config.exs.eex",
     app: "templates/new/lib/app.ex.eex",
+    assets: "templates/new/lib/assets.ex.eex",
     scene_home: "templates/new/lib/scenes/home.ex.eex"
   ]
 

--- a/lib/mix/tasks/scenic.gen.component.ex
+++ b/lib/mix/tasks/scenic.gen.component.ex
@@ -44,7 +44,20 @@ defmodule Mix.Tasks.Scenic.Gen.Component do
     component_path = "lib/components/#{component_filename}.ex"
     create_directory("lib/components")
     create_file(component_path, component_new_template(component_module: inspect(full_module)))
-    Mix.shell().info("Created component #{component_module}.")
+
+    Mix.shell().info("""
+    Created component #{component_module}.
+
+    You can add it to your scene with:
+
+    graph
+    |> MyApp.Component.#{component_module}.add_to_graph(
+      "My Component",
+      translate: {100, 100}
+    )
+
+    Note: ensure that push_graph is called after the component is added to the graph.
+    """)
   end
 
   # ============================================================================

--- a/templates/gen_component/lib/components/component.ex.eex
+++ b/templates/gen_component/lib/components/component.ex.eex
@@ -1,37 +1,48 @@
 defmodule <%= @component_module %> do
-    require Logger  
-    use Scenic.Component
-    import Scenic.Primitives, only: [{:text, 3}, {:update_opts, 2}]
+  require Logger
+  use Scenic.Component
+  import Scenic.Primitives
+  alias Scenic.Graph
 
-    @graph Graph.build()
-    |> text("", text_align: :center, translate: {100, 200}, id: :text)
+  # You can add it to your scene with:
+  #
+  # graph
+  # |> MyApp.Component.#{component_module}.add_to_graph(
+  #   "My Component",
+  #   translate: {100, 100}
+  # )
 
-    @impl Scenic.Component
-    def info( data ), do: """
-    #{IO.ANSI.red()}#{__MODULE__} data must be a bitstring
-    #{IO.ANSI.yellow()}Received: #{inspect(data)}
-    #{IO.ANSI.default_color()}
-    """
+  @graph Graph.build()
+         |> text("", text_align: :center, translate: {100, 200}, id: :text)
 
-    @impl Scenic.Component
-    def verify( text ) when is_bitstring(text), do: {:ok, text}
-    def verify( _ ), do: :invalid_data
+  @impl Scenic.Component
+  def validate(text) when is_bitstring(text), do: {:ok, text}
 
-    @impl Scenic.Scene
-    def init( text, opts ) do
-        # modify the already built graph
-        graph = @graph
-        |> Graph.modify(:_root_, &update_opts(&1, styles: opts[:styles]) )
-        |> Graph.modify(:text, &text(&1, text) )
+  def validate(data) do
+    {:error,
+     """
+     #{IO.ANSI.red()}#{__MODULE__} data must be a bitstring
+     #{IO.ANSI.yellow()}Received: #{inspect(data)}
+     #{IO.ANSI.default_color()}
+     """}
+  end
 
-        state = %{
-        graph: graph,
-        text: text
-        }
+  @impl Scenic.Scene
+  def init(scene, text, opts) do
+    # modify the already built graph
+    graph =
+      @graph
+      |> Graph.modify(:_root_, &update_opts(&1, styles: opts[:styles]))
+      |> Graph.modify(:text, &text(&1, text))
 
-        {:ok, state, push: graph}
-    end
+    scene =
+      scene
+      |> assign(text: text)
+      |> push_graph(graph)
 
-    @impl Scenic.Scene
-    def handle_input(_event, _context, state), do: {:noreply, state}
+    {:ok, scene}
+  end
+
+  @impl Scenic.Scene
+  def handle_input(_event, _context, scene), do: {:noreply, scene}
 end

--- a/templates/gen_scene/lib/scenes/scene.ex.eex
+++ b/templates/gen_scene/lib/scenes/scene.ex.eex
@@ -3,37 +3,44 @@ defmodule <%= inspect(@scene_module) %> do
   require Logger
 
   alias Scenic.Graph
-  alias Scenic.ViewPort
 
   import Scenic.Primitives
 
   @text_size 24
 
+  @note """
+  This is an example scene generated with
+
+  `mix scenic.gen.scene`
+  """
+
   @impl Scenic.Scene
-  def init(_, opts) do
+  def init(scene, _args, _opts) do
     # get the width and height of the viewport. This is to demonstrate creating
     # a transparent full-screen rectangle to catch user input
-    {:ok, %ViewPort.Status{size: {width, height}}} = ViewPort.info(opts[:viewport])
+    %Scenic.ViewPort{size: {width, height}} = scene.viewport
 
-    # show the version of scenic and the glfw driver
+    # show the version of scenic and the local driver
     scenic_ver = Application.spec(:scenic, :vsn) |> to_string()
-    glfw_ver = Application.spec(:scenic_driver_glfw, :vsn) |> to_string()
+    driver_local_version = Application.spec(:scenic_driver_local, :vsn) |> to_string()
 
     graph =
       Graph.build(font: :roboto, font_size: @text_size)
       |> add_specs_to_graph([
+        rect_spec({width, height}, fill: :clear, input: [:cursor_button, :cursor_pos]),
         text_spec("scenic: v" <> scenic_ver, translate: {20, 40}),
-        text_spec("glfw: v" <> glfw_ver, translate: {20, 40 + @text_size}),
-        text_spec(@note, translate: {20, 120}),
-        rect_spec({width, height})
+        text_spec("local_driver: v" <> driver_local_version, translate: {20, 40 + @text_size}),
+        text_spec(@note, translate: {20, 120})
       ])
 
-    {:ok, graph, push: graph}
+    scene = push_graph(scene, graph)
+
+    {:ok, scene}
   end
 
   @impl Scenic.Scene
-  def handle_input(event, _context, state) do
+  def handle_input(event, _context, scene) do
     Logger.info("Received event: #{inspect(event)}")
-    {:noreply, state}
+    {:noreply, scene}
   end
 end

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -26,3 +26,6 @@ foo-*.tar
 # Ignore scripts marked as secret - usually passwords and such in config files
 *.secret.exs
 *.secrets.exs
+
+# Ignore generated static Scenic asset files
+priv/__scenic/

--- a/templates/new/config/config.exs.eex
+++ b/templates/new/config/config.exs.eex
@@ -3,18 +3,23 @@
 use Mix.Config
 
 # Configure the main viewport for the Scenic application
-config :<%= @app %>, :viewport, %{
+config :<%= @app %>, :viewport,
   name: :main_viewport,
   size: {700, 600},
   default_scene: {<%= @mod %>.Scene.Home, nil},
   drivers: [
-    %{
-      module: Scenic.Driver.Glfw,
-      name: :glfw,
-      opts: [resizeable: false, title: "<%= @app %>"]
-    }
+    [
+      module: Scenic.Driver.Local,
+      name: :local,
+      window: [
+        title: "<%= @app %>",
+        resizeable: true
+      ],
+      on_close: :stop_system
+    ]
   ]
-}
+
+config :scenic, :assets, module: <%= @mod %>.Assets
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/templates/new/lib/app.ex.eex
+++ b/templates/new/lib/app.ex.eex
@@ -9,7 +9,7 @@ defmodule <%= @mod %> do
 
     # start the application with the viewport
     children = [
-      {Scenic, viewports: [main_viewport_config]}
+      {Scenic, [main_viewport_config]}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/templates/new/lib/assets.ex.eex
+++ b/templates/new/lib/assets.ex.eex
@@ -1,0 +1,3 @@
+defmodule <%= @mod %>.Assets do
+  use Scenic.Assets.Static, otp_app: :<%= @app %>
+end

--- a/templates/new/lib/scenes/home.ex.eex
+++ b/templates/new/lib/scenes/home.ex.eex
@@ -3,17 +3,16 @@ defmodule <%= @mod %>.Scene.Home do
   require Logger
 
   alias Scenic.Graph
-  alias Scenic.ViewPort
 
   import Scenic.Primitives
   # import Scenic.Components
 
   @note """
-    This is a very simple starter application.
+  This is a very simple starter application.
 
-    If you want a more full-on example, please start from:
+  If you want a more full-on example, please start from:
 
-    mix scenic.new.example
+  mix scenic.new.example
   """
 
   @text_size 24
@@ -22,25 +21,30 @@ defmodule <%= @mod %>.Scene.Home do
   # setup
 
   # --------------------------------------------------------
-  def init(_, opts) do
+  def init(scene, _opts, _scenic_opts) do
     # get the width and height of the viewport. This is to demonstrate creating
     # a transparent full-screen rectangle to catch user input
-    {:ok, %ViewPort.Status{size: {width, height}}} = ViewPort.info(opts[:viewport])
+    %Scenic.ViewPort{size: {width, height}} = scene.viewport
 
-    # show the version of scenic and the glfw driver
+    # This is required if you want to detect when the user presses a key on their keyboard
+    Scenic.Scene.capture_input(scene, [:key])
+
+    # These variables will be used to show the version of scenic and the local driver
     scenic_ver = Application.spec(:scenic, :vsn) |> to_string()
-    glfw_ver = Application.spec(:scenic_driver_glfw, :vsn) |> to_string()
+    driver_local_version = Application.spec(:scenic_driver_local, :vsn) |> to_string()
 
     graph =
       Graph.build(font: :roboto, font_size: @text_size)
       |> add_specs_to_graph([
+        rect_spec({width, height}, fill: :clear, input: [:cursor_button, :cursor_pos]),
         text_spec("scenic: v" <> scenic_ver, translate: {20, 40}),
-        text_spec("glfw: v" <> glfw_ver, translate: {20, 40 + @text_size}),
-        text_spec(@note, translate: {20, 120}),
-        rect_spec({width, height})
+        text_spec("local_driver: v" <> driver_local_version, translate: {20, 40 + @text_size}),
+        text_spec(@note, translate: {20, 120})
       ])
 
-    {:ok, graph, push: graph}
+    scene = push_graph(scene, graph)
+
+    {:ok, scene}
   end
 
   def handle_input(event, _context, state) do

--- a/templates/new/mix.exs.eex
+++ b/templates/new/mix.exs.eex
@@ -6,7 +6,7 @@ defmodule <%= @mod %>.MixProject do
       app: :<%= @app %>,
       version: "0.1.0",
       elixir: "~> 1.7",
-      build_embedded: true,
+      build_embedded: false,
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
@@ -23,8 +23,8 @@ defmodule <%= @mod %>.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:scenic, "~> 0.10"},
-      {:scenic_driver_glfw, "~> 0.10", targets: :host},
+      {:scenic, github: "boydm/scenic", branch: "v0.11"},
+      {:scenic_driver_local, github: "ScenicFramework/scenic_driver_local"}
     ]
   end
 end

--- a/templates/new_example/mix.exs.eex
+++ b/templates/new_example/mix.exs.eex
@@ -24,7 +24,7 @@ defmodule <%= @mod %>.MixProject do
   defp deps do
     [
       {:scenic, "~> 0.10"},
-      {:scenic_driver_glfw, "~> 0.10", targets: :host},
+      {:scenic_driver_local, "~> 0.1", targets: :host},
 
       # These deps are optional and are included as they are often used.
       # If your app doesn't need them, they are safe to remove.

--- a/templates/new_nerves/mix.exs.eex
+++ b/templates/new_nerves/mix.exs.eex
@@ -47,7 +47,7 @@ defmodule <%= @mod %>.MixProject do
       {:scenic_sensor, "~> 0.7"},
 
       # Dependencies for only the :host
-      {:scenic_driver_glfw, "~> 0.10", targets: :host},
+      {:scenic_driver_local, "~> 0.1", targets: :host},
 
       # Dependencies for all targets except :host
       {:nerves_runtime, "~> 0.9", targets: @all_targets},

--- a/test/scenic_new_example_test.exs
+++ b/test/scenic_new_example_test.exs
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Scenic.NewExampleTest do
                  assert file =~ "mod: {#{@module_name}, []}"
 
                  assert file =~ "{:scenic, \"~> 0.10\"}"
-                 assert file =~ "{:scenic_driver_glfw, \"~> 0.10\", targets: :host}"
+                 assert file =~ "{:scenic_driver_local, \"~> 0.1\", targets: :host}"
                end)
              end) =~ "Your Scenic project was created successfully."
     end)

--- a/test/scenic_new_nerves_test.exs
+++ b/test/scenic_new_nerves_test.exs
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Scenic.New.NervesTest do
 
                assert_file("#{@app_name}/mix.exs", fn file ->
                  assert file =~ "{:scenic, \"~> 0.10\"}"
-                 assert file =~ "{:scenic_driver_glfw, \"~> 0.10\", targets: :host}"
+                 assert file =~ "{:scenic_driver_local, \"~> 0.1\", targets: :host}"
 
                  assert file =~
                           "{:scenic_driver_nerves_touch, \"~> 0.10\", targets: @all_targets}"

--- a/test/scenic_new_test.exs
+++ b/test/scenic_new_test.exs
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Scenic.NewTest do
 
                  assert file =~ "default_scene: {#{@module_name}.Scene.Home, nil}"
 
-                 assert file =~ ", title: \"#{@app_name}\""
+                 assert file =~ "title: \"#{@app_name}\""
                end)
 
                assert_file("#{@app_name}/lib/#{@app_name}.ex", fn file ->
@@ -37,8 +37,11 @@ defmodule Mix.Tasks.Scenic.NewTest do
                assert_file("#{@app_name}/mix.exs", fn file ->
                  assert file =~ "mod: {#{@module_name}, []}"
 
-                 assert file =~ "{:scenic, \"~> 0.10\"}"
-                 assert file =~ "{:scenic_driver_glfw, \"~> 0.10\", targets: :host}"
+                 # assert file =~ "{:scenic, \"~> 0.10\"}"
+                 assert file =~ "{:scenic, github: \"boydm/scenic\", branch: \"v0.11\"}"
+
+                 # assert file =~ "{:scenic_driver_local, \"~> 0.1\"}"
+                 assert file =~ "{:scenic_driver_local, github: \"ScenicFramework/scenic_driver_local\"}"
                end)
              end) =~ "Your Scenic project was created successfully."
     end)


### PR DESCRIPTION
Only update `new`, `gen_scene`, and `gen_component`

Switch to scenic_driver_local
Add a usage statement for gen_component
A few stylistic changes
Switch build_embedded to false to workaround a bug
Switch the scenic dep to the v0.11 branch (will need to be updated once a release is cut, along with scenic_driver_local)